### PR TITLE
changes by pint update to 0.9.5

### DIFF
--- a/recipes/pulsar_phase/gammapy-pint-environment.yml
+++ b/recipes/pulsar_phase/gammapy-pint-environment.yml
@@ -5,8 +5,8 @@ channels:
   - conda-forge
 
 dependencies:
-  - gammapy=1.0
+  - gammapy=1.0.1
   - python=3.9
   - pip
   - pip:
-      - pint-pulsar~=0.9.3
+      - pint-pulsar~=0.9.5

--- a/recipes/pulsar_phase/pulsar_phase_computation.ipynb
+++ b/recipes/pulsar_phase/pulsar_phase_computation.ipynb
@@ -15,9 +15,9 @@
    "source": [
     "This notebook has been done for the following version of Gammapy and PINT:\n",
     "\n",
-    "Gammapy version : 1.0\n",
+    "Gammapy version : 1.0.1\n",
     "\n",
-    "PINT version : 0.9.3"
+    "PINT version : 0.9.5"
    ]
   },
   {
@@ -81,8 +81,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Gammapy version : 1.0\n",
-      "PINT version : 0.9.3\n"
+      "Gammapy version : 1.0.1\n",
+      "PINT version : 0.9.5\n"
      ]
     }
    ],
@@ -400,7 +400,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-03-21 15:31:25.068 | INFO     | pint.models.absolute_phase:validate:72 - TZRFRQ was 0.0 or None. Setting to infinite frequency.\n"
+      "\u001b[32m2023-05-04 17:33:12.530\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpint.models.absolute_phase\u001b[0m:\u001b[36mvalidate\u001b[0m:\u001b[36m72\u001b[0m - \u001b[1mTZRFRQ was 0.0 or None. Setting to infinite frequency.\u001b[0m\n"
      ]
     },
     {
@@ -436,7 +436,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/mregeard/anaconda3/envs/gammapy-1.0-pint/lib/python3.9/site-packages/pint/models/model_builder.py:110: UserWarning: Unrecognized parfile line 'EPHVER 5'\n",
+      "/Users/mregeard/anaconda3/envs/gammapy-1.0.1-pint/lib/python3.9/site-packages/pint/models/model_builder.py:139: UserWarning: Unrecognized parfile line 'EPHVER 5'\n",
       "  warnings.warn(f\"Unrecognized parfile line '{p_line}'\", UserWarning)\n"
      ]
     }
@@ -471,31 +471,31 @@
    "execution_count": 15,
    "id": "a145cdde",
    "metadata": {
-    "scrolled": true
+    "scrolled": false
    },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-03-21 15:31:25.793 | DEBUG    | pint.toa:__init__:1327 - No pulse number flags found in the TOAs\n",
-      "2023-03-21 15:31:25.802 | DEBUG    | pint.toa:apply_clock_corrections:2132 - Applying clock corrections (include_gps = False, include_bipm = False)\n",
-      "2023-03-21 15:31:26.214 | INFO     | pint.observatory.topo_obs:clock_corrections:353 - Observatory magic requires no clock corrections.\n",
-      "2023-03-21 15:31:28.404 | DEBUG    | pint.toa:compute_TDBs:2182 - Computing TDB columns.\n",
-      "2023-03-21 15:31:28.405 | DEBUG    | pint.toa:compute_TDBs:2207 - Using EPHEM = DE421 for TDB calculation.\n",
-      "2023-03-21 15:31:29.282 | DEBUG    | pint.toa:compute_posvels:2298 - Computing PosVels of observatories and Earth, using DE421\n",
-      "2023-03-21 15:31:29.475 | INFO     | pint.solar_system_ephemerides:_load_kernel_link:53 - Set solar system ephemeris to de421 from download\n",
-      "2023-03-21 15:31:30.431 | DEBUG    | pint.toa:compute_posvels:2353 - SSB obs pos [1.47007462e+11 2.56889811e+10 1.11245045e+10] m\n",
-      "2023-03-21 15:31:30.435 | INFO     | pint.solar_system_ephemerides:_load_kernel_link:53 - Set solar system ephemeris to de421 from download\n",
-      "2023-03-21 15:31:30.448 | DEBUG    | pint.toa:compute_posvels:2367 - Adding columns ssb_obs_pos ssb_obs_vel obs_sun_pos\n"
+      "\u001b[32m2023-05-04 17:33:12.819\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpint.toa\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m1340\u001b[0m - \u001b[34m\u001b[1mNo pulse number flags found in the TOAs\u001b[0m\n",
+      "\u001b[32m2023-05-04 17:33:12.829\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpint.toa\u001b[0m:\u001b[36mapply_clock_corrections\u001b[0m:\u001b[36m2182\u001b[0m - \u001b[34m\u001b[1mApplying clock corrections (include_gps = False, include_bipm = False)\u001b[0m\n",
+      "\u001b[32m2023-05-04 17:33:13.240\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpint.observatory.topo_obs\u001b[0m:\u001b[36mclock_corrections\u001b[0m:\u001b[36m357\u001b[0m - \u001b[1mObservatory magic requires no clock corrections.\u001b[0m\n",
+      "\u001b[32m2023-05-04 17:33:15.579\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpint.toa\u001b[0m:\u001b[36mcompute_TDBs\u001b[0m:\u001b[36m2233\u001b[0m - \u001b[34m\u001b[1mComputing TDB columns.\u001b[0m\n",
+      "\u001b[32m2023-05-04 17:33:15.579\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpint.toa\u001b[0m:\u001b[36mcompute_TDBs\u001b[0m:\u001b[36m2254\u001b[0m - \u001b[34m\u001b[1mUsing EPHEM = DE421 for TDB calculation.\u001b[0m\n",
+      "\u001b[32m2023-05-04 17:33:16.392\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpint.toa\u001b[0m:\u001b[36mcompute_posvels\u001b[0m:\u001b[36m2332\u001b[0m - \u001b[34m\u001b[1mComputing PosVels of observatories and Earth, using DE421\u001b[0m\n",
+      "\u001b[32m2023-05-04 17:33:17.268\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpint.solar_system_ephemerides\u001b[0m:\u001b[36m_load_kernel_link\u001b[0m:\u001b[36m55\u001b[0m - \u001b[1mSet solar system ephemeris to de421 from download\u001b[0m\n",
+      "\u001b[32m2023-05-04 17:33:18.294\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpint.toa\u001b[0m:\u001b[36mcompute_posvels\u001b[0m:\u001b[36m2385\u001b[0m - \u001b[34m\u001b[1mSSB obs pos [1.47007462e+11 2.56889811e+10 1.11245045e+10] m\u001b[0m\n",
+      "\u001b[32m2023-05-04 17:33:18.913\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpint.solar_system_ephemerides\u001b[0m:\u001b[36m_load_kernel_link\u001b[0m:\u001b[36m55\u001b[0m - \u001b[1mSet solar system ephemeris to de421 from download\u001b[0m\n",
+      "\u001b[32m2023-05-04 17:33:18.942\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpint.toa\u001b[0m:\u001b[36mcompute_posvels\u001b[0m:\u001b[36m2399\u001b[0m - \u001b[34m\u001b[1mAdding columns ssb_obs_pos ssb_obs_vel obs_sun_pos\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 5.28 s, sys: 73.3 ms, total: 5.35 s\n",
-      "Wall time: 5.37 s\n"
+      "CPU times: user 5.07 s, sys: 98.8 ms, total: 5.17 s\n",
+      "Wall time: 6.41 s\n"
      ]
     }
    ],
@@ -512,14 +512,13 @@
     "planets = False\n",
     "\n",
     "# Create a TOA object for each time\n",
-    "toa_list = list(toa.TOA(MJD=t, error=1 * u.microsecond, obs='magic') for t in times)\n",
-    "\n",
-    "# Create a TOAs object from a list of TOA\n",
-    "ts = toa.get_TOAs_list(toa_list,\n",
-    "                       ephem='DE421', \n",
-    "                       include_gps=include_gps,  \n",
-    "                       include_bipm=include_bipm, \n",
-    "                       planets=planets) "
+    "toas = toa.get_TOAs_array(times=times, \n",
+    "                              obs='magic', \n",
+    "                              errors=1 * u.microsecond,\n",
+    "                              ephem='DE421', \n",
+    "                              include_gps=include_gps, \n",
+    "                              include_bipm=include_bipm, \n",
+    "                              planets=planets)"
    ]
   },
   {
@@ -540,25 +539,25 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-03-21 15:31:30.557 | DEBUG    | pint.models.glitch:glitch_phase:212 - Glitch phase for glitch 1: 0.0 \n",
-      "2023-03-21 15:31:30.588 | DEBUG    | pint.models.absolute_phase:get_TZR_toa:97 - Creating and dealing with the single TZR_toa for absolute phase\n",
-      "2023-03-21 15:31:30.589 | DEBUG    | pint.toa:__init__:1327 - No pulse number flags found in the TOAs\n",
-      "2023-03-21 15:31:30.589 | DEBUG    | pint.toa:apply_clock_corrections:2132 - Applying clock corrections (include_gps = False, include_bipm = False)\n",
-      "2023-03-21 15:31:30.590 | DEBUG    | pint.toa:compute_TDBs:2182 - Computing TDB columns.\n",
-      "2023-03-21 15:31:30.591 | DEBUG    | pint.toa:compute_TDBs:2207 - Using EPHEM = DE421 for TDB calculation.\n",
-      "2023-03-21 15:31:30.592 | DEBUG    | pint.toa:compute_posvels:2298 - Computing PosVels of observatories and Earth, using DE421\n",
-      "2023-03-21 15:31:30.595 | INFO     | pint.solar_system_ephemerides:_load_kernel_link:53 - Set solar system ephemeris to de421 from download\n",
-      "2023-03-21 15:31:30.600 | DEBUG    | pint.toa:compute_posvels:2353 - SSB obs pos [-1.49278181e+08  7.07659442e+06  3.07113250e+06] km\n",
-      "2023-03-21 15:31:30.602 | INFO     | pint.solar_system_ephemerides:_load_kernel_link:53 - Set solar system ephemeris to de421 from download\n",
-      "2023-03-21 15:31:30.603 | DEBUG    | pint.toa:compute_posvels:2367 - Adding columns ssb_obs_pos ssb_obs_vel obs_sun_pos\n",
-      "2023-03-21 15:31:30.603 | DEBUG    | pint.models.absolute_phase:get_TZR_toa:110 - Done with TZR_toa\n",
-      "2023-03-21 15:31:30.636 | DEBUG    | pint.models.glitch:glitch_phase:212 - Glitch phase for glitch 1: 0.0 \n"
+      "\u001b[32m2023-05-04 17:33:19.082\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpint.models.glitch\u001b[0m:\u001b[36mglitch_phase\u001b[0m:\u001b[36m212\u001b[0m - \u001b[34m\u001b[1mGlitch phase for glitch 1: 0.0 \u001b[0m\n",
+      "\u001b[32m2023-05-04 17:33:19.097\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpint.models.absolute_phase\u001b[0m:\u001b[36mget_TZR_toa\u001b[0m:\u001b[36m97\u001b[0m - \u001b[34m\u001b[1mCreating and dealing with the single TZR_toa for absolute phase\u001b[0m\n",
+      "\u001b[32m2023-05-04 17:33:19.099\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpint.toa\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m1340\u001b[0m - \u001b[34m\u001b[1mNo pulse number flags found in the TOAs\u001b[0m\n",
+      "\u001b[32m2023-05-04 17:33:19.099\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpint.toa\u001b[0m:\u001b[36mapply_clock_corrections\u001b[0m:\u001b[36m2182\u001b[0m - \u001b[34m\u001b[1mApplying clock corrections (include_gps = False, include_bipm = False)\u001b[0m\n",
+      "\u001b[32m2023-05-04 17:33:19.101\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpint.toa\u001b[0m:\u001b[36mcompute_TDBs\u001b[0m:\u001b[36m2233\u001b[0m - \u001b[34m\u001b[1mComputing TDB columns.\u001b[0m\n",
+      "\u001b[32m2023-05-04 17:33:19.101\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpint.toa\u001b[0m:\u001b[36mcompute_TDBs\u001b[0m:\u001b[36m2254\u001b[0m - \u001b[34m\u001b[1mUsing EPHEM = DE421 for TDB calculation.\u001b[0m\n",
+      "\u001b[32m2023-05-04 17:33:19.103\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpint.toa\u001b[0m:\u001b[36mcompute_posvels\u001b[0m:\u001b[36m2332\u001b[0m - \u001b[34m\u001b[1mComputing PosVels of observatories and Earth, using DE421\u001b[0m\n",
+      "\u001b[32m2023-05-04 17:33:19.713\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpint.solar_system_ephemerides\u001b[0m:\u001b[36m_load_kernel_link\u001b[0m:\u001b[36m55\u001b[0m - \u001b[1mSet solar system ephemeris to de421 from download\u001b[0m\n",
+      "\u001b[32m2023-05-04 17:33:19.725\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpint.toa\u001b[0m:\u001b[36mcompute_posvels\u001b[0m:\u001b[36m2385\u001b[0m - \u001b[34m\u001b[1mSSB obs pos [-1.49278181e+08  7.07659442e+06  3.07113250e+06] km\u001b[0m\n",
+      "\u001b[32m2023-05-04 17:33:20.364\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpint.solar_system_ephemerides\u001b[0m:\u001b[36m_load_kernel_link\u001b[0m:\u001b[36m55\u001b[0m - \u001b[1mSet solar system ephemeris to de421 from download\u001b[0m\n",
+      "\u001b[32m2023-05-04 17:33:20.375\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpint.toa\u001b[0m:\u001b[36mcompute_posvels\u001b[0m:\u001b[36m2399\u001b[0m - \u001b[34m\u001b[1mAdding columns ssb_obs_pos ssb_obs_vel obs_sun_pos\u001b[0m\n",
+      "\u001b[32m2023-05-04 17:33:20.379\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpint.models.absolute_phase\u001b[0m:\u001b[36mget_TZR_toa\u001b[0m:\u001b[36m119\u001b[0m - \u001b[34m\u001b[1mDone with TZR_toa\u001b[0m\n",
+      "\u001b[32m2023-05-04 17:33:20.456\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpint.models.glitch\u001b[0m:\u001b[36mglitch_phase\u001b[0m:\u001b[36m212\u001b[0m - \u001b[34m\u001b[1mGlitch phase for glitch 1: 0.0 \u001b[0m\n"
      ]
     }
    ],
    "source": [
     "# Compute phases\n",
-    "phases = model.phase(ts,abs_phase=True)[1]\n",
+    "phases = model.phase(toas,abs_phase=True)[1]\n",
     "                \n",
     "# Shift phases to the interval (0,1]\n",
     "phases = np.where(phases < 0.0 , phases + 1.0 , phases)"
@@ -686,7 +685,7 @@
      "data": {
       "text/html": [
        "<div><i>Table length=11189</i>\n",
-       "<table id=\"table6168636960\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<table id=\"table6217718128\" class=\"table-striped table-bordered table-condensed\">\n",
        "<thead><tr><th>EVENT_ID</th><th>TIME</th><th>RA</th><th>DEC</th><th>ENERGY</th><th>PHASE</th></tr></thead>\n",
        "<thead><tr><th></th><th>s</th><th>deg</th><th>deg</th><th>TeV</th><th></th></tr></thead>\n",
        "<thead><tr><th>int64</th><th>float64</th><th>float32</th><th>float32</th><th>float32</th><th>float64</th></tr></thead>\n",
@@ -898,7 +897,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "COLUMN_PHASE: PHASE; PINT_VERS: 0.9.3; GAMMAPY_VERS: 1.0; EPHEM_FILE: ./0534+2200_ApJ_708_1254_2010.par; PSRJ :J0534+2200; START: 54686.1526259; FINISH: 56583.1591704; TZRMJD: 55638.155277599951656; TZRSITE: coe; TZRFREQ: inf; EPHEM: DE405; EPHEM_RA: 5.575538888888889; EPHEM_DEC: 22.01447222222222; PHASE_OFFSET: default = 0; DATE: 60024.6052163847;\n"
+      "COLUMN_PHASE: PHASE; PINT_VERS: 0.9.5; GAMMAPY_VERS: 1.0.1; EPHEM_FILE: ./0534+2200_ApJ_708_1254_2010.par; PSRJ :J0534+2200; START: 54686.1526259; FINISH: 56583.1591704; TZRMJD: 55638.155277599951656; TZRSITE: coe; TZRFREQ: inf; EPHEM: DE405; EPHEM_RA: 5.575538888888889; EPHEM_DEC: 22.01447222222222; PHASE_OFFSET: default = 0; DATE: 60068.64815403606;\n"
      ]
     }
    ],
@@ -963,7 +962,7 @@
        "             ('ALT_PNT', 69.69974),\n",
        "             ('AZ_PNT', 103.8848),\n",
        "             ('PH_LOG',\n",
-       "              'COLUMN_PHASE: PHASE; PINT_VERS: 0.9.3; GAMMAPY_VERS: 1.0; EPHEM_FILE: ./0534+2200_ApJ_708_1254_2010.par; PSRJ :J0534+2200; START: 54686.1526259; FINISH: 56583.1591704; TZRMJD: 55638.155277599951656; TZRSITE: coe; TZRFREQ: inf; EPHEM: DE405; EPHEM_RA: 5.575538888888889; EPHEM_DEC: 22.01447222222222; PHASE_OFFSET: default = 0; DATE: 60024.6052163847;')])"
+       "              'COLUMN_PHASE: PHASE; PINT_VERS: 0.9.5; GAMMAPY_VERS: 1.0.1; EPHEM_FILE: ./0534+2200_ApJ_708_1254_2010.par; PSRJ :J0534+2200; START: 54686.1526259; FINISH: 56583.1591704; TZRMJD: 55638.155277599951656; TZRSITE: coe; TZRFREQ: inf; EPHEM: DE405; EPHEM_RA: 5.575538888888889; EPHEM_DEC: 22.01447222222222; PHASE_OFFSET: default = 0; DATE: 60068.64815403606;')])"
       ]
      },
      "execution_count": 25,
@@ -988,7 +987,18 @@
    "execution_count": 26,
    "id": "12545bff",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "'THETA' axis is stored as a scalar -- converting to 1D array.\n",
+      "'THETA' axis is stored as a scalar -- converting to 1D array.\n",
+      "'THETA' axis is stored as a scalar -- converting to 1D array.\n",
+      "'THETA' axis is stored as a scalar -- converting to 1D array.\n"
+     ]
+    }
+   ],
    "source": [
     "# Create new event list and add it to observation object\n",
     "new_event_list = EventList(table)\n",
@@ -997,7 +1007,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 27,
    "id": "1ac16c51",
    "metadata": {},
    "outputs": [
@@ -1005,7 +1015,7 @@
      "data": {
       "text/html": [
        "<div><i>Table length=11189</i>\n",
-       "<table id=\"table6168636960\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<table id=\"table6217718128\" class=\"table-striped table-bordered table-condensed\">\n",
        "<thead><tr><th>EVENT_ID</th><th>TIME</th><th>RA</th><th>DEC</th><th>ENERGY</th><th>PHASE</th></tr></thead>\n",
        "<thead><tr><th></th><th>s</th><th>deg</th><th>deg</th><th>TeV</th><th></th></tr></thead>\n",
        "<thead><tr><th>int64</th><th>float64</th><th>float32</th><th>float32</th><th>float32</th><th>float64</th></tr></thead>\n",
@@ -1097,7 +1107,7 @@
        "  356526 333780040.52476007  84.86929 21.290916  0.13630114  0.29983901925054285"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1126,7 +1136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "id": "f3c8410c",
    "metadata": {},
    "outputs": [
@@ -1136,7 +1146,7 @@
        "PosixPath('/Users/mregeard/Workspace/data/gammapy-data/gammapy-datasets/dev/magic/rad_max/data')"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1147,7 +1157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "id": "8fd2ce31",
    "metadata": {},
    "outputs": [],
@@ -1164,7 +1174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 30,
    "id": "e6e38fc1",
    "metadata": {},
    "outputs": [
@@ -1174,7 +1184,7 @@
        "'/Users/mregeard/Workspace/data/gammapy-data/gammapy-datasets/dev/magic/rad_max/data/pulsar_events_file/'"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1185,7 +1195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 31,
    "id": "f339c797",
    "metadata": {
     "scrolled": true
@@ -1215,7 +1225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 32,
    "id": "4b8dd431",
    "metadata": {},
    "outputs": [
@@ -1223,7 +1233,7 @@
      "data": {
       "text/html": [
        "<div><i>HDUIndexTable length=10</i>\n",
-       "<table id=\"table6194761792\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<table id=\"table6215170032\" class=\"table-striped table-bordered table-condensed\">\n",
        "<thead><tr><th>OBS_ID</th><th>HDU_TYPE</th><th>HDU_CLASS</th><th>FILE_DIR</th><th>FILE_NAME</th><th>HDU_NAME</th></tr></thead>\n",
        "<thead><tr><th>int64</th><th>bytes30</th><th>bytes30</th><th>bytes100</th><th>bytes50</th><th>bytes30</th></tr></thead>\n",
        "<tr><td>5029748</td><td>events</td><td>events</td><td>./</td><td>20131004_05029748_DL3_CrabNebula-W0.40+215.fits</td><td>EVENTS</td></tr>\n",
@@ -1255,7 +1265,7 @@
        "5029747    edisp   edisp_2d       ./ 20131004_05029747_DL3_CrabNebula-W0.40+035.fits ENERGY DISPERSION"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1268,7 +1278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 33,
    "id": "6f37e101",
    "metadata": {},
    "outputs": [],
@@ -1281,7 +1291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 34,
    "id": "d89a7739",
    "metadata": {},
    "outputs": [
@@ -1289,7 +1299,7 @@
      "data": {
       "text/html": [
        "<div><i>HDUIndexTable length=10</i>\n",
-       "<table id=\"table6194761792\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<table id=\"table6215170032\" class=\"table-striped table-bordered table-condensed\">\n",
        "<thead><tr><th>OBS_ID</th><th>HDU_TYPE</th><th>HDU_CLASS</th><th>FILE_DIR</th><th>FILE_NAME</th><th>HDU_NAME</th></tr></thead>\n",
        "<thead><tr><th>int64</th><th>bytes30</th><th>bytes30</th><th>bytes100</th><th>bytes50</th><th>bytes30</th></tr></thead>\n",
        "<tr><td>5029748</td><td>events</td><td>events</td><td>./</td><td>20131004_05029748_DL3_CrabNebula-W0.40+215.fits</td><td>EVENTS</td></tr>\n",
@@ -1321,7 +1331,7 @@
        "5029747    edisp   edisp_2d                    ./ 20131004_05029747_DL3_CrabNebula-W0.40+035.fits ENERGY DISPERSION"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1348,7 +1358,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 35,
    "id": "b1633cd5",
    "metadata": {},
    "outputs": [],
@@ -1382,7 +1392,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 36,
    "id": "88a0e9c1",
    "metadata": {},
    "outputs": [],
@@ -1392,7 +1402,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 37,
    "id": "f7c60c18",
    "metadata": {},
    "outputs": [
@@ -1402,7 +1412,7 @@
        "['events', 'gti', 'aeff', 'edisp', 'rad_max']"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1414,7 +1424,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 38,
    "id": "4ae8ebd2",
    "metadata": {},
    "outputs": [
@@ -1422,7 +1432,7 @@
      "data": {
       "text/html": [
        "<div><i>Table length=11189</i>\n",
-       "<table id=\"table6193496176\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<table id=\"table6216094816\" class=\"table-striped table-bordered table-condensed\">\n",
        "<thead><tr><th>EVENT_ID</th><th>TIME</th><th>RA</th><th>DEC</th><th>ENERGY</th></tr></thead>\n",
        "<thead><tr><th></th><th>s</th><th>deg</th><th>deg</th><th>TeV</th></tr></thead>\n",
        "<thead><tr><th>int64</th><th>float64</th><th>float32</th><th>float32</th><th>float32</th></tr></thead>\n",
@@ -1514,7 +1524,7 @@
        "  356526 333780040.52476007  84.86929 21.290916  0.13630114"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1573,7 +1583,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.15"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Recently PINT released there latest version 0.9.5, which include a method called `get_TOAs_array` which allow to create a `TOAS` object directly from an array of times. 

I replaced our code by this where it was necessary. 

I also replaced gammapy1.0 by gammapy1.0.1 and pint-pulsar~=0.9.3 by pint-pulsar~=0.9.5 in the environement file. 